### PR TITLE
Fix flu_flusion Python 3.9 compatibility

### DIFF
--- a/src/flu_flusion/main.py
+++ b/src/flu_flusion/main.py
@@ -2,6 +2,7 @@ import click
 import datetime
 from dateutil import relativedelta
 import subprocess
+from typing import Optional
 
 @click.command()
 @click.option(
@@ -15,7 +16,7 @@ import subprocess
     is_flag=True,
     help="Perform a short run."
 )
-def main(today_date: str | None = None, short_run: bool = False):
+def main(today_date: Optional[str] = None, short_run: bool = False):
     """Generate flu predictions from flusion model and plot them."""
     try:
         today_date = datetime.date.fromisoformat(today_date)
@@ -28,9 +29,9 @@ def main(today_date: str | None = None, short_run: bool = False):
     else:
         short_run_flag = []
     
-    subprocess.run(["python", "0_ar6_pooled.py",
+    subprocess.run(["python3", "0_ar6_pooled.py",
                     "--reference_date", str(reference_date)] + short_run_flag)
-    subprocess.run(["python", "1_gbqr.py",
+    subprocess.run(["python3", "1_gbqr.py",
                     "--reference_date", str(reference_date)] + short_run_flag)
     subprocess.run(["Rscript", "2_flusion_ensemble.R", str(reference_date)])
     # subprocess.run(["Rscript", "3_plot.R", str(reference_date)])


### PR DESCRIPTION
First co-authorship experience with Claude! This PR should be a simple update to `main.py. There's some funny business with typesetting that I had Claude help me diagnose, and its suggestion seems good. 
This is also in preparation for a modified version of Flusion.

- Replace str | None type hint with Optional[str] from typing module
- Change subprocess calls from 'python' to 'python3'

The pipe operator (|) for type unions was introduced in Python 3.10. This change ensures compatibility with Python 3.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)