### PR TITLE
Add derived_task_ids property in tasks.json

### DIFF
--- a/hub-config/tasks.json
+++ b/hub-config/tasks.json
@@ -201,7 +201,8 @@
             "submissions_due": {
                 "start": "1900-01-01",
                 "end": "2900-12-31"
-            }
+            },
+            "derived_task_ids": ["target_end_date"]
         }
     ],
     "output_type_id_datatype": "auto",


### PR DESCRIPTION
This is necessary for validation to work properly with required horizon values. See details here: https://docs.hubverse.io/en/latest/user-guide/tasks.html#derived-task-id-variables